### PR TITLE
Set Mend severity threshold to HIGH

### DIFF
--- a/repo-config.json
+++ b/repo-config.json
@@ -8,7 +8,7 @@
     "useMendCheckNames": true
   },
   "issueSettings": {
-    "minSeverityLevel": "LOW",
+    "minSeverityLevel": "HIGH",
     "issueType": "DEPENDENCY"
   }
 }


### PR DESCRIPTION
- Changed minSeverityLevel from LOW to HIGH
- Reduces noise while catching critical vulnerabilities
- More manageable for initial rollout